### PR TITLE
General improvements for use in CUDAnative.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![Build Status](https://travis-ci.org/JuliaGPU/Adapt.jl.svg?branch=master)](https://travis-ci.org/JuliaGPU/Adapt.jl)
 
-The `adapt(T, x)` function acts like `convert(T, x)`, but without the restriction of returning a `T`. This allows you to "convert" wrapper types like `Adjoint` to be GPU compatible (for example) without throwing away the wrapper.
+The `adapt(T, x)` function acts like `convert(T, x)`, but without the
+restriction of returning a `T`. This allows you to "convert" wrapper types like
+`Adjoint` to be GPU compatible (for example) without throwing away the wrapper.
 
-e.g.
+For example:
 
 ```julia
 adapt(CuArray, ::Adjoint{Array})::Adjoint{CuArray}

--- a/README.md
+++ b/README.md
@@ -12,15 +12,28 @@ For example:
 adapt(CuArray, ::Adjoint{Array})::Adjoint{CuArray}
 ```
 
-New data types like `Adjoint` should overload `adapt(T, ::Adjoint)` (usually just to forward the call to `adapt`).
+New wrapper types like `Adjoint` should overload `adapt_structure(T, ::Adjoint)`
+(usually just to forward the call to `adapt`):
 
 ```julia
-adapt(T, x::Adjoint) = Adjoint(adapt(T, parent(x)))
+Adapt.adapt_structure(to, x::Adjoint) = Adjoint(adapt(to, parent(x)))
 ```
 
-New adaptor types like `CuArray` should overload `adapt_` for compatible types.
+A similar function, `adapt_storage`, can be used to define the conversion
+behavior for the innermost storage types:
 
 ```julia
-adapt_(::Type{<:CuArray}, xs::AbstractArray) =
-  isbits(xs) ? xs : convert(CuArray, xs)
+adapt_storage(::Type{<:CuArray}, xs::AbstractArray) = convert(CuArray, xs)
 ```
+
+Implementations of `adapt_storage` will typically be part of libraries that use
+Adapt. For example, CuArrays.jl defines methods of
+`adapt_storage(::Type{<:CuArray}, ...)` and uses that to convert different kinds
+of arrays, while CUDAnative.jl provides implementations of
+`adapt_storage(::CUDAnative.Adaptor, ...)` to convert various values to
+GPU-compatible alternatives.
+
+Packages that define new wrapper types and want to be compatible with packages
+that use Adapt.jl should provide implementations of `adapt_structure` that
+preserve the wrapper type. Adapt.jl already provides such methods for array
+wrappers that are part of the Julia standard library.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+environment:
+  matrix:
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+matrix:
+  allow_failures:
+  - julia_version: nightly
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -1,14 +1,16 @@
 module Adapt
 
-using LinearAlgebra
+export adapt, AbstractAdaptor
 
-adapt_(T, x) = x
+abstract type AbstractAdaptor end
 
-adapt(T, x) = adapt_(T, x)
+# external interface
+adapt(A::AbstractAdaptor, x) = adapt_structure(A, x)
 
-# Base integrations
+# interface for libraries to implement
+adapt_structure(A::AbstractAdaptor, x) = adapt_storage(A, x)
+adapt_storage(::AbstractAdaptor, x) = x
 
-adapt(T, x::Adjoint) = Adjoint(adapt(T, parent(x)))
-adapt(T, x::Transpose) = Transpose(adapt(T, parent(x)))
+include("base.jl")
 
 end # module

--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -1,15 +1,13 @@
 module Adapt
 
-export adapt, AbstractAdaptor
-
-abstract type AbstractAdaptor end
+export adapt
 
 # external interface
-adapt(A::AbstractAdaptor, x) = adapt_structure(A, x)
+adapt(to, x) = adapt_structure(to, x)
 
 # interface for libraries to implement
-adapt_structure(A::AbstractAdaptor, x) = adapt_storage(A, x)
-adapt_storage(::AbstractAdaptor, x) = x
+adapt_structure(to, x) = adapt_storage(to, x)
+adapt_storage(to, x) = x
 
 include("base.jl")
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -2,26 +2,26 @@
 
 ## Base
 
-adapt_structure(A::AbstractAdaptor, xs::Tuple) = Tuple(adapt(A, x) for x in xs)
-@generated adapt_structure(A::AbstractAdaptor, x::NamedTuple) =
-    Expr(:tuple, (:($f=adapt(A, x.$f)) for f in fieldnames(x))...)
+adapt_structure(to, xs::Tuple) = Tuple(adapt(to, x) for x in xs)
+@generated adapt_structure(to, x::NamedTuple) =
+    Expr(:tuple, (:($f=adapt(to, x.$f)) for f in fieldnames(x))...)
 
-adapt(A::AbstractAdaptor, x::SubArray) = SubArray(adapt(A, parent(x)), parentindices(x))
+adapt(to, x::SubArray) = SubArray(adapt(to, parent(x)), parentindices(x))
 
 
 ## LinearAlgebra
 
 import LinearAlgebra: Adjoint, Transpose
-adapt_structure(A::AbstractAdaptor, x::Adjoint)   = Adjoint(adapt(A, parent(x)))
-adapt_structure(A::AbstractAdaptor, x::Transpose) = Transpose(adapt(A, parent(x)))
+adapt_structure(to, x::Adjoint)   = Adjoint(adapt(to, parent(x)))
+adapt_structure(to, x::Transpose) = Transpose(adapt(to, parent(x)))
 
 
 ## Broadcast
 
 import Base.Broadcast: Broadcasted, Extruded
 
-adapt_structure(A::AbstractAdaptor, bc::Broadcasted{Style}) where Style =
-  Broadcasted{Style}(bc.f, map(arg->adapt(A, arg), bc.args), bc.axes)
+adapt_structure(to, bc::Broadcasted{Style}) where Style =
+  Broadcasted{Style}(bc.f, map(arg->adapt(to, arg), bc.args), bc.axes)
 
-adapt_structure(A::AbstractAdaptor, ex::Extruded) =
-    Extruded(adapt(A, ex.x), ex.keeps, ex.defaults)
+adapt_structure(to, ex::Extruded) =
+    Extruded(adapt(to, ex.x), ex.keeps, ex.defaults)

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,0 +1,14 @@
+# predefined adaptors for working with types from the Julia standard library
+
+## Base
+
+adapt_structure(A::AbstractAdaptor, xs::Tuple) = Tuple(adapt(A, x) for x in xs)
+@generated adapt_structure(A::AbstractAdaptor, x::NamedTuple) =
+    Expr(:tuple, (:($f=adapt(A, x.$f)) for f in fieldnames(x))...)
+
+
+## LinearAlgebra
+
+import LinearAlgebra: Adjoint, Transpose
+adapt_structure(A::AbstractAdaptor, x::Adjoint)   = Adjoint(adapt(A, parent(x)))
+adapt_structure(A::AbstractAdaptor, x::Transpose) = Transpose(adapt(A, parent(x)))

--- a/src/base.jl
+++ b/src/base.jl
@@ -6,9 +6,22 @@ adapt_structure(A::AbstractAdaptor, xs::Tuple) = Tuple(adapt(A, x) for x in xs)
 @generated adapt_structure(A::AbstractAdaptor, x::NamedTuple) =
     Expr(:tuple, (:($f=adapt(A, x.$f)) for f in fieldnames(x))...)
 
+adapt(A::AbstractAdaptor, x::SubArray) = SubArray(adapt(A, parent(x)), parentindices(x))
+
 
 ## LinearAlgebra
 
 import LinearAlgebra: Adjoint, Transpose
 adapt_structure(A::AbstractAdaptor, x::Adjoint)   = Adjoint(adapt(A, parent(x)))
 adapt_structure(A::AbstractAdaptor, x::Transpose) = Transpose(adapt(A, parent(x)))
+
+
+## Broadcast
+
+import Base.Broadcast: Broadcasted, Extruded
+
+adapt_structure(A::AbstractAdaptor, bc::Broadcasted{Style}) where Style =
+  Broadcasted{Style}(bc.f, map(arg->adapt(A, arg), bc.args), bc.axes)
+
+adapt_structure(A::AbstractAdaptor, ex::Extruded) =
+    Extruded(adapt(A, ex.x), ex.keeps, ex.defaults)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ struct Matrix
     mat::AbstractArray
 end
 
-struct MatrixAdaptor <: Adapt.AbstractAdaptor end
+struct MatrixAdaptor end
 
 Adapt.adapt_structure(::MatrixAdaptor, xs::AbstractArray) = Matrix(xs)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-import Adapt: adapt, adapt_
+using Adapt
 using Test
 
 # trivial test
@@ -7,11 +7,12 @@ struct Matrix
     mat::AbstractArray
 end
 
-adapt_(::Type{<:Matrix}, xs::AbstractArray) =
-  Matrix(xs)
+struct MatrixAdaptor <: Adapt.AbstractAdaptor end
+
+Adapt.adapt_structure(::MatrixAdaptor, xs::AbstractArray) = Matrix(xs)
 
 testmat = [12;34;56;78]
 
 testresult = Matrix(testmat)
 
-@test adapt(Matrix, testmat) == testresult
+@test adapt(MatrixAdaptor(), testmat) == testresult

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,18 +1,51 @@
 using Adapt
 using Test
 
-# trivial test
 
-struct Matrix
-    mat::AbstractArray
+# custom array type
+
+struct CustomArray{T,N} <: AbstractArray{T,N}
+    arr::AbstractArray
 end
 
-struct MatrixAdaptor end
+CustomArray(x::AbstractArray{T,N}) where {T,N} = CustomArray{T,N}(x)
+Adapt.adapt_storage(::Type{<:CustomArray}, xs::AbstractArray) = CustomArray(xs)
 
-Adapt.adapt_structure(::MatrixAdaptor, xs::AbstractArray) = Matrix(xs)
+Base.size(x::CustomArray, y...) = size(x.arr, y...)
+Base.getindex(x::CustomArray, y...) = getindex(x.arr, y...)
 
-testmat = [12;34;56;78]
 
-testresult = Matrix(testmat)
+const val = CustomArray{Float64,2}(rand(2,2))
 
-@test adapt(MatrixAdaptor(), testmat) == testresult
+# basic adaption
+@test adapt(CustomArray, val.arr) == val
+@test adapt(CustomArray, val.arr) isa CustomArray
+
+# idempotency
+@test adapt(CustomArray, val) == val
+@test adapt(CustomArray, val) isa CustomArray
+
+# custom wrapper
+struct Wrapper{T}
+    arr::T
+end
+Wrapper(x::T) where T = Wrapper{T}(x)
+Adapt.adapt_structure(to, xs::Wrapper) = Wrapper(adapt(to, xs.arr))
+@test adapt(CustomArray, Wrapper(val.arr)) == Wrapper(val)
+@test adapt(CustomArray, Wrapper(val.arr)) isa Wrapper{<:CustomArray}
+
+
+## base wrappers
+
+@test adapt(CustomArray, (val.arr,)) == (val,)
+
+@test adapt(CustomArray, (a=val.arr,)) == (a=val,)
+
+@test adapt(CustomArray, view(val.arr,:,:)) == view(val,:,:)
+@test adapt(CustomArray, view(val.arr,:,:)) isa SubArray{<:Any,<:Any,<:CustomArray}
+
+
+using LinearAlgebra
+
+@test adapt(CustomArray, val.arr') == val'
+@test adapt(CustomArray, val.arr') isa Adjoint{<:Any,<:CustomArray}


### PR DESCRIPTION
Redesign as an attempt to address https://github.com/JuliaGPU/CUDAnative.jl/issues/121

There's been lots of duplication between `CUDAnative.cudaconvert` and `adapt`, so it makes sense to try and merge them. However, `cudaconvert` was designed to "convert for execution on CUDA GPUs" (ie. towards an environment/context), while `adapt` is more like a generalized form of `convert` (ie. towards a type), so there's a difference in how these APIs are used and extended.

In many cases though, adapting towards a specific type doesn't make much sense IMO. Having people do or implement `adapt(CuDeviceArray, arr)` seems awfully specific, and doesn't solve the problem of conversions that do not yield a CuDeviceArray. So in this PR I propose to use a `AbstractAdaptor` type hierarchy for deciding how to adapt structs. It should be possible to express the same things we're doing right now with `adapt`, and make it possible to replace `cudaconvert` by having a CUDA adaptor and dispatch on that.

I've also renamed `adapt` and `adapt_` to `adapt_structure`/`adapt_storage` which seems to match the pattern that matters 99% of the time (but feel free to bikeshed on this one).

Single-blob version of the diff in this PR + usage in external libraries:

```julia
## Adapt.jl

export adapt, AbstractAdaptor

abstract type AbstractAdaptor end

# external interface
adapt(A::Type{AbstractAdaptor}, x) = adapt_structure(A, x)

# interface for libraries to implement
# two levels of priority:
# - structure, eg. array wrappers, should get preserved and get priority in dispatch
# - storage, eg. CuArray
adapt_structure(A::Type{AbstractAdaptor}, x) = adapt_storage(A, x)
adapt_storage(::Type{AbstractAdaptor}, x) = x

# Base
adapt_structure(A::Type{<:AbstractAdaptor}, xs::Tuple) = Tuple(adapt(A, x) for x in xs)
@generated adapt_structure(A::Type{<:AbstractAdaptor}, x::NamedTuple) =
    Expr(:tuple, (:($f=adapt(A, x.$f)) for f in fieldnames(x))...)

# LinearAlgebra
import LinearAlgebra: Adjoint, Transpose
adapt_structure(A::Type{AbstractAdaptor}, x::Adjoint)   = Adjoint(adapt(A, parent(x)))
adapt_structure(A::Type{AbstractAdaptor}, x::Transpose) = Transpose(adapt(A, parent(x)))


## CUDAnative

struct CUDAAdaptor <: AbstractAdaptor end


## CuArrays.jl

adapt_storage(::Type{CUDAAdaptor}, x::Array) = (println("adapt $(typeof(x)) to CuDeviceArray"); x)


## User

adapt(CUDAAdaptor, [1]')

```
