### PR TITLE
simplify code for adapting (Named)Tuples and fix adapting NamedTuple()

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -2,20 +2,7 @@
 
 ## Base
 
-#adapt_structure(to, xs::Tuple) = Tuple(adapt(to, x) for x in xs)
-#
-# non-allocating version
-#@generated adapt_structure(to, x::Tuple) =
-#    Expr(:tuple, (:(adapt(to, x[$i])) for i in 1:fieldcount(x))...)
-#
-# non-allocating, non-@generated version
-adapt_structure(to, xs::Tuple) = _adapt_structure(to, xs)
-_adapt_structure(to, xs::Tuple{}) = ()
-_adapt_structure(to, xs::Tuple) =
-    tuple(adapt(to, xs[1]), _adapt_structure(to, Base.tail(xs))...)
-
-@generated adapt_structure(to, x::NamedTuple) =
-    Expr(:tuple, (:($f=adapt(to, x.$f)) for f in fieldnames(x))...)
+adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(x->adapt(to,x), xs)
 
 
 ## Array wrappers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ Adapt.adapt_structure(to, xs::Wrapper) = Wrapper(adapt(to, xs.arr))
 
 ## base wrappers
 
+@test @inferred(adapt(nothing, NamedTuple())) == NamedTuple()
 @test adapt(CustomArray, (val.arr,)) == (val,)
 @test @allocated(adapt(nothing, ())) == 0
 @test @allocated(adapt(nothing, (1,))) == 0


### PR DESCRIPTION
I simplified the code for adapting Tuples and NamedTuples without breaking any of the tests (I'm not seeing any other obvious impact on inferability or allocations). I also fixed the fact that previously `adapt(NamedTuple())` was returning `Tuple()` instead of `NamedTuple()` (and added a test for this).