### PR TITLE
remove unused type parameters that cause inlining issues

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -59,9 +59,9 @@ const WrappedArray{T,N,Src,Dst} = @eval Union{$([W for (W,ctor) in Adapt._wrappe
 # https://github.com/JuliaLang/julia/pull/31563
 
 # accessors for extracting information about the wrapper type
-Base.ndims(W::Type{<:WrappedArray{T,N,Src,Dst}}) where {T,N,Src,Dst} = @isdefined(N) ? N : specialized_ndims(W)
-Base.eltype(::Type{<:WrappedArray{T,N,Src,Dst}}) where {T,N,Src,Dst} = T  # every wrapper has a T typevar
-Base.parent(W::Type{<:WrappedArray{T,N,Src,Dst}}) where {T,N,Src,Dst} = @isdefined(Dst) ? Dst.name.wrapper : Src.name.wrapper
+Base.ndims(W::Type{<:WrappedArray{<:Any,N}}) where {N} = @isdefined(N) ? N : specialized_ndims(W)
+Base.eltype(::Type{<:WrappedArray{T}}) where {T} = T  # every wrapper has a T typevar
+Base.parent(::Type{<:WrappedArray{<:Any,<:Any,Src,Dst}}) where {Src,Dst} = @isdefined(Dst) ? Dst.name.wrapper : Src.name.wrapper
 
 # some wrappers don't have a N typevar because it is constant, but we can't extract that from <:WrappedArray
 specialized_ndims(::Type{<:LinearAlgebra.Adjoint}) = 2


### PR DESCRIPTION
Before:
```
julia> f(a) = eltype(a)
f (generic function with 1 method)

julia> @code_typed f(B)
CodeInfo(
1 ─     return Float64
) => Type{Float64}

julia> using Adapt
[ Info: Precompiling Adapt [79e6a3ab-5dfb-504d-930d-738a2a938a0e]

julia> @code_typed f(B)
CodeInfo(
1 ─ %1 = invoke Main.eltype(_2::SubArray{Float64,1,Array{Float64,2},Tuple{Base.Slice{Base.OneTo{Int64}},Int64},true})::Core.Compiler.Const(Float64, false)
└──      return %1
) => Type{Float64}

```

After:
```
julia> using Adapt
[ Info: Precompiling Adapt [79e6a3ab-5dfb-504d-930d-738a2a938a0e]

julia> @code_typed f(B)
CodeInfo(
1 ─     return Float64
) => Type{Float64}
```

x-ref: https://github.com/JuliaGPU/Adapt.jl/pull/23/commits/2a8e74d640c846aacc762cf68227958d0520067b#r443848813