### PR TITLE
Make ndims and parent inferrable

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,4 +107,10 @@ const du = CustomArray{Float64,1}(rand(2))
 const d = CustomArray{Float64,1}(rand(3))
 @test_adapt CustomArray Tridiagonal(dl.arr, d.arr, du.arr) Tridiagonal(dl, d, du) AnyCustomArray
 
-@test ndims(LinearAlgebra.Transpose{Float64,Array{Float64,1}}) == 2
+@testset "Extracting type information" begin
+    @test ndims(LinearAlgebra.Transpose{Float64,Array{Float64,1}}) == 2
+    @test ndims(Adapt.WrappedSubArray{Float64,3,Array{Float64,3}}) == 3
+
+    @test parent(LinearAlgebra.Transpose{Float64,Array{Float64,1}}) == Array
+    @test parent(Adapt.WrappedSubArray{Float64,3,Array{Float64,3}}) == Array
+end


### PR DESCRIPTION
Previously, the `@isdefined` conditionals prevented julia from inferring the type of these
methods at compile time. With this change broadcast operations in CUDA.jl like `C .- a'`
can now be fully inferred which was previously impossible because the
BroadcastStyle (which uses ndims internally) could not be decided at compile time.