### PR TITLE
Adapting closures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.1'
           - '1.2'
           - '1.3'
           - '1.4'

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "3.0.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-julia = "1.0"
+julia = "1.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/base.jl
+++ b/src/base.jl
@@ -3,6 +3,26 @@
 adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(x->adapt(to,x), xs)
 
 
+## Closures
+
+# two things can be captured: static parameters, and actual values (fields)
+
+@eval function adapt_structure(to, f::F) where {F<:Function}
+  isempty(F.parameters) && return f
+  nsparams = length(F.parameters) - nfields(f)
+
+  # TODO: we should adapt the static parameters too
+  #       (but adapt currently only works with values)
+  sparams = ntuple(i->F.parameters[i], nsparams)
+  fields = ntuple(i->adapt(to, getfield(f, i)), nfields(f))
+
+  # TODO: this assumes the typevars of the closure matches the sparams + fields.
+  #       that may not always be true, and definitely isn't for arbitrary callable objects.
+  ftyp = F.name.wrapper{sparams..., map(Core.Typeof, fields)...}
+  $(Expr(:splatnew, :ftyp, :fields))
+end
+
+
 ## Broadcast
 
 import Base.Broadcast: Broadcasted, Extruded

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,39 @@ Adapt.adapt_structure(to, xs::Wrapper) = Wrapper(adapt(to, xs.arr))
 
 end
 
+# NOTE: if we put this in the preceding testset, unrelated tests start to allocate
+@testset "closures" begin
+
+# basic capture of a variable
+function closure1(x)
+    function foobar()
+        x
+    end
+    foobar
+end
+
+f = closure1(mat)
+@test f() == mat
+f′ = adapt(CustomArray, f)
+@test f′() == mat.arr
+@test @inferred(adapt(nothing, f)()) == f()
+
+# closure with sparams
+function closure2(A::CustomArray{T}=zeros(1), b::Number=0) where {T}
+    function f()
+        convert(T, 0)
+        A, A[1] == b
+    end
+    f
+end
+
+f = closure2(mat)
+@test f() == (mat, false)
+f′ = adapt(CustomArray, f)
+@test f′() == (mat.arr, false)
+
+end
+
 
 @testset "array wrappers" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,12 +20,15 @@ const vec = CustomArray{Float64,1}(rand(2))
 
 const mat_bools = CustomArray{Bool,2}(rand(Bool,2,2))
 
-macro test_adapt(to, src, dst, typ=nothing)
+macro test_adapt(to, src_expr, dst_expr, typ=nothing)
     quote
-        @test adapt($to, $src) == $dst
-        @test typeof(adapt($to, $src)) == typeof($dst)
-        if $typ !== nothing
-            @test typeof($dst) <: $typ
+        src = $(esc(src_expr))
+        dst = $(esc(dst_expr))
+
+        @test adapt($(esc(to)), src) == dst
+        @test typeof(adapt($(esc(to)), src)) == typeof(dst)
+        if $(esc(typ)) !== nothing
+            @test typeof(dst) <: $(esc(typ))
         end
     end
 end
@@ -48,7 +51,7 @@ Adapt.adapt_structure(to, xs::Wrapper) = Wrapper(adapt(to, xs.arr))
 @test_adapt CustomArray Wrapper(mat.arr) Wrapper(mat)
 
 
-## base wrappers
+@testset "base structures" begin
 
 @test @inferred(adapt(nothing, NamedTuple())) == NamedTuple()
 @test_adapt CustomArray (mat.arr,) (mat,)
@@ -58,8 +61,13 @@ Adapt.adapt_structure(to, xs::Wrapper) = Wrapper(adapt(to, xs.arr))
 
 @test_adapt CustomArray (a=mat.arr,) (a=mat,)
 
+end
+
+
+@testset "array wrappers" begin
+
 @test_adapt CustomArray view(mat.arr,:,:) view(mat,:,:) AnyCustomArray
-const inds = CustomArray{Int,1}([1,2])
+inds = CustomArray{Int,1}([1,2])
 @test_adapt CustomArray view(mat.arr,inds.arr,:) view(mat,inds,:) AnyCustomArray
 
 # NOTE: manual creation of PermutedDimsArray because permutedims collects
@@ -102,12 +110,15 @@ using LinearAlgebra
 
 @test_adapt CustomArray Diagonal(vec.arr) Diagonal(vec) AnyCustomArray
 
-const dl = CustomArray{Float64,1}(rand(2))
-const du = CustomArray{Float64,1}(rand(2))
-const d = CustomArray{Float64,1}(rand(3))
+dl = CustomArray{Float64,1}(rand(2))
+du = CustomArray{Float64,1}(rand(2))
+d = CustomArray{Float64,1}(rand(3))
 @test_adapt CustomArray Tridiagonal(dl.arr, d.arr, du.arr) Tridiagonal(dl, d, du) AnyCustomArray
 
-@testset "Extracting type information" begin
+end
+
+
+@testset "type information" begin
     @test Adapt.ndims(LinearAlgebra.Transpose{Float64,Array{Float64,1}}) == 2
     @test Adapt.ndims(Adapt.WrappedSubArray{Float64,3,Array{Float64,3}}) == 3
 


### PR DESCRIPTION
```julia
julia> using CUDA, Adapt

julia> function foo(A)
       bar() = A
       bar
       end
foo (generic function with 1 method)

julia> f = foo(rand(2,2))
(::var"#bar#1"{Matrix{Float64}}) (generic function with 1 method)

julia> f()
2×2 Matrix{Float64}:
 0.167181  0.62589
 0.174081  0.464358

julia> g = Adapt.adapt(CuArray, f)
(::var"#bar#1"{CuArray{Float64, 2}}) (generic function with 1 method)

julia> g()
2×2 CuArray{Float64, 2}:
 0.167181  0.62589
 0.174081  0.464358
```