### PR TITLE
Add support for `LinearAlgebra.Symmetric`

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -41,6 +41,8 @@ adapt_structure(to, A::LinearAlgebra.Diagonal) =
       LinearAlgebra.Diagonal(adapt(to, Base.parent(A)))
 adapt_structure(to, A::LinearAlgebra.Tridiagonal) =
       LinearAlgebra.Tridiagonal(adapt(to, A.dl), adapt(to, A.d), adapt(to, A.du))
+adapt_structure(to, A::LinearAlgebra.Symmetric) =
+      LinearAlgebra.Symmetric(adapt(to, Base.parent(A)))
 
 
 # we generally don't support multiple layers of wrappers, but some occur often
@@ -92,6 +94,7 @@ WrappedArray{T,N,Src,Dst} = Union{
       LinearAlgebra.UnitUpperTriangular{T,<:Dst},
       LinearAlgebra.Diagonal{T,<:Dst},
       LinearAlgebra.Tridiagonal{T,<:Dst},
+      LinearAlgebra.Symmetric{T,<:Dst},
 
       WrappedReinterpretArray{T,N,<:Src},
       WrappedReshapedArray{T,N,<:Src},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,7 +164,6 @@ using LinearAlgebra
 @test_adapt CustomArray UnitUpperTriangular(mat.arr) UnitUpperTriangular(mat) AnyCustomArray
 @test_adapt CustomArray Symmetric(mat.arr) Symmetric(mat) AnyCustomArray
 
-
 @test_adapt CustomArray Diagonal(vec.arr) Diagonal(vec) AnyCustomArray
 
 dl = CustomArray{Float64,1}(rand(2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,6 +162,8 @@ using LinearAlgebra
 @test_adapt CustomArray UnitLowerTriangular(mat.arr) UnitLowerTriangular(mat) AnyCustomArray
 @test_adapt CustomArray UpperTriangular(mat.arr) UpperTriangular(mat) AnyCustomArray
 @test_adapt CustomArray UnitUpperTriangular(mat.arr) UnitUpperTriangular(mat) AnyCustomArray
+@test_adapt CustomArray Symmetric(mat.arr) Symmetric(mat) AnyCustomArray
+
 
 @test_adapt CustomArray Diagonal(vec.arr) Diagonal(vec) AnyCustomArray
 


### PR DESCRIPTION
This PR makes the following code run without errors:
```julia
using CUDA, LinearAlgebra
CUDA.allowscalar(false)

A = CUDA.randn(4, 4)
@show Symmetric(A)
```