### PR TITLE
Move `GPUArrays.backend` here

### DIFF
--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -52,4 +52,6 @@ include("arrays.jl")
 # helpers
 include("macro.jl")
 
+function backend end
+
 end # module


### PR DESCRIPTION
This function is the last piece we need to enable gpu broadcast for `StructArray`.
Move it here as `Adapt` is more lightweight.
