### PR TITLE
RFC: Establish concept of a computing device

### DIFF
--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -52,4 +52,7 @@ include("arrays.jl")
 # helpers
 include("macro.jl")
 
+# compute devices
+include("computedevs.jl")
+
 end # module

--- a/src/computedevs.jl
+++ b/src/computedevs.jl
@@ -4,7 +4,7 @@
 """
     abstract type AbstractComputingDevice
 
-Supertype for CPU and GPU computing devices.
+Supertype for arbitrary computing devices (CPU, GPU, etc.).
 
 `adapt(dev::AbstractComputingDevice, x)` adapts `x` for `dev`.
 """

--- a/src/computedevs.jl
+++ b/src/computedevs.jl
@@ -1,0 +1,80 @@
+# adaptors for converting abstract arrays to Base.Array
+
+
+"""
+    abstract type AbstractComputingDevice
+
+Supertype for CPU and GPU computing devices.
+
+`adapt(dev::AbstractComputingDevice, x)` adapts `x` for `dev`.
+"""
+abstract type AbstractComputingDevice end
+export AbstractComputingDevice
+
+
+"""
+    struct ComputingDeviceIndependent <: AbstractComputingDevice
+
+`get_computing_device(x) === ComputingDeviceIndependent()` indicates
+that `x` is not tied to a specific computing device. This typically
+means that x is a statically allocated object.
+"""
+struct ComputingDeviceIndependent <: AbstractComputingDevice end
+export ComputingDeviceIndependent
+
+
+"""
+    struct CPUDevice <: AbstractComputingDevice
+
+`CPUDevice()` is the default CPU device.
+"""
+struct CPUDevice <: AbstractComputingDevice end
+export CPUDevice
+
+
+
+"""
+    abstract type AbstractGPUDevice <: AbstractComputingDevice
+
+Supertype for GPU computing devices.
+"""
+abstract type AbstractGPUDevice <: AbstractComputingDevice end
+export AbstractGPUDevice
+
+
+
+const _incompatible_devs = ArgumentError("Incompatible computing devices")
+
+select_computing_device(a::ComputingDeviceIndependent, ::ComputingDeviceIndependent) = a
+select_computing_device(a::ComputingDeviceIndependent, b::AbstractComputingDevice) = b
+select_computing_device(a::AbstractComputingDevice, b::ComputingDeviceIndependent) = a
+
+select_computing_device(a::CPUDevice, ::CPUDevice) = a
+select_computing_device(a::CPUDevice, b::AbstractGPUDevice) = a
+select_computing_device(a::AbstractGPUDevice, b::CPUDevice) = b
+select_computing_device(a::AbstractGPUDevice, b::AbstractGPUDevice) = (a === b) ? a : throw(_incompatible_devs)
+
+
+"""
+    get_computing_device(x)::AbstractComputingDevice
+
+Get the computing device backing object `x`.
+"""
+function get_computing_device end
+export get_computing_device
+
+
+@inline get_computing_device(::Array) = CPUDevice()
+
+# ToDo: Utilize `ArrayInterfaceCore.buffer(A)`? Would require Adapt to depend
+# on ArrayInterfaceCore.
+
+@generated function get_computing_device(x)
+    impl = :(begin dev_0 = ComputingDeviceIndependent() end)
+    append!(impl.args, [:($(Symbol(:dev_, i)) = select_computing_device(get_computing_device(getfield(x, $i)), $(Symbol(:dev_, i-1)))) for i in 1:fieldcount(x)])
+    push!(impl.args, :(return $(Symbol(:dev_, fieldcount(x)))))
+    impl
+end
+
+
+adapt_storage(::CPUDevice, x) = adapt_storage(Array, x)

--- a/src/computedevs.jl
+++ b/src/computedevs.jl
@@ -2,79 +2,159 @@
 
 
 """
-    abstract type AbstractComputingDevice
+    abstract type AbstractComputeUnit
 
 Supertype for arbitrary computing devices (CPU, GPU, etc.).
 
-`adapt(dev::AbstractComputingDevice, x)` adapts `x` for `dev`.
+`adapt(dev::AbstractComputeUnit, x)` adapts `x` for `dev`.
+
+`Sys.total_memory(dev)` and `Sys.free_memory(dev)` return the total and free
+memory on the device.
 """
-abstract type AbstractComputingDevice end
-export AbstractComputingDevice
+abstract type AbstractComputeUnit end
+export AbstractComputeUnit
 
 
 """
-    struct ComputingDeviceIndependent <: AbstractComputingDevice
+    struct ComputingDeviceIndependent
 
-`get_computing_device(x) === ComputingDeviceIndependent()` indicates
+`get_compute_unit(x) === ComputingDeviceIndependent()` indicates
 that `x` is not tied to a specific computing device. This typically
 means that x is a statically allocated object.
 """
-struct ComputingDeviceIndependent <: AbstractComputingDevice end
+struct ComputingDeviceIndependent end
 export ComputingDeviceIndependent
 
 
 """
-    struct CPUDevice <: AbstractComputingDevice
+    UnknownComputeUnitOf(x)
 
-`CPUDevice()` is the default CPU device.
+`get_compute_unit(x) === ComputingDeviceIndependent()` indicates
+that the computing device for `x` cannot be determined.
 """
-struct CPUDevice <: AbstractComputingDevice end
-export CPUDevice
-
-
-
-"""
-    abstract type AbstractGPUDevice <: AbstractComputingDevice
-
-Supertype for GPU computing devices.
-"""
-abstract type AbstractGPUDevice <: AbstractComputingDevice end
-export AbstractGPUDevice
-
-
-
-const _incompatible_devs = ArgumentError("Incompatible computing devices")
-
-select_computing_device(a::ComputingDeviceIndependent, ::ComputingDeviceIndependent) = a
-select_computing_device(a::ComputingDeviceIndependent, b::AbstractComputingDevice) = b
-select_computing_device(a::AbstractComputingDevice, b::ComputingDeviceIndependent) = a
-
-select_computing_device(a::CPUDevice, ::CPUDevice) = a
-select_computing_device(a::CPUDevice, b::AbstractGPUDevice) = a
-select_computing_device(a::AbstractGPUDevice, b::CPUDevice) = b
-select_computing_device(a::AbstractGPUDevice, b::AbstractGPUDevice) = (a === b) ? a : throw(_incompatible_devs)
-
-
-"""
-    get_computing_device(x)::AbstractComputingDevice
-
-Get the computing device backing object `x`.
-"""
-function get_computing_device end
-export get_computing_device
-
-
-@inline get_computing_device(::Array) = CPUDevice()
-
-# ToDo: Utilize `ArrayInterfaceCore.buffer(A)`? Would require Adapt to depend
-# on ArrayInterfaceCore.
-
-@generated function get_computing_device(x)
-    impl = :(begin dev_0 = ComputingDeviceIndependent() end)
-    append!(impl.args, [:($(Symbol(:dev_, i)) = select_computing_device(get_computing_device(getfield(x, $i)), $(Symbol(:dev_, i-1)))) for i in 1:fieldcount(x)])
-    push!(impl.args, :(return $(Symbol(:dev_, fieldcount(x)))))
-    impl
+struct UnknownComputeUnitOf{T}
+    x::T
 end
 
 
+"""
+    struct MixedComputeSystem <: AbstractComputeUnit
+
+A (possibly heterogenous) system of multiple compute units.
+"""
+struct MixedComputeSystem <: AbstractComputeUnit end
+export MixedComputeSystem
+
+
+"""
+    struct CPUDevice <: AbstractComputeUnit
+
+`CPUDevice()` is the default CPU device.
+"""
+struct CPUDevice <: AbstractComputeUnit end
+export CPUDevice
+
 adapt_storage(::CPUDevice, x) = adapt_storage(Array, x)
+
+Sys.total_memory(::CPUDevice) = Sys.total_memory()
+Sys.free_memory(::CPUDevice) = Sys.free_memory()
+
+
+"""
+    abstract type AbstractComputeAccelerator <: AbstractComputeUnit
+
+Supertype for GPU computing devices.
+"""
+abstract type AbstractComputeAccelerator <: AbstractComputeUnit end
+export AbstractComputeAccelerator
+
+
+"""
+    abstract type AbstractGPUDevice <: AbstractComputeAccelerator
+
+Supertype for GPU computing devices.
+"""
+abstract type AbstractGPUDevice <: AbstractComputeAccelerator end
+export AbstractGPUDevice
+
+
+merge_compute_units() = ComputingDeviceIndependent()
+
+@inline function merge_compute_units(a, b, c, ds::Vararg{Any,N}) where N
+    a_b = merge_compute_units(a,b)
+    return merge_compute_units(a_b, c, ds...)
+end
+
+@inline merge_compute_units(a::UnknownComputeUnitOf, b::UnknownComputeUnitOf) = a
+@inline merge_compute_units(a::UnknownComputeUnitOf, b::Any) = a
+@inline merge_compute_units(a::Any, b::UnknownComputeUnitOf) = b
+
+@inline function merge_compute_units(a, b)
+    return (a === b) ? a : compute_unit_mergeresult(
+        compute_unit_mergerule(a, b),
+        compute_unit_mergerule(b, a),
+    )
+end
+
+struct NoCUnitMergeRule end
+
+@inline compute_unit_mergerule(a::Any, b::Any) = NoCUnitMergeRule()
+@inline compute_unit_mergerule(a::UnknownComputeUnitOf, b::Any) = a
+@inline compute_unit_mergerule(a::UnknownComputeUnitOf, b::UnknownComputeUnitOf) = a
+@inline compute_unit_mergerule(a::ComputingDeviceIndependent, b::Any) = b
+
+@inline compute_unit_mergeresult(a_b::NoCUnitMergeRule, b_a::NoCUnitMergeRule) = MixedComputeSystem()
+@inline compute_unit_mergeresult(a_b, b_a::NoCUnitMergeRule) = a_b
+@inline compute_unit_mergeresult(a_b::NoCUnitMergeRule, b_a) = b_a
+@inline compute_unit_mergeresult(a_b, b_a) = a_b === b_a ? a_b : MixedComputeSystem()
+
+
+"""
+    get_compute_unit(x)::Union{
+        AbstractComputeUnit,
+        ComputingDeviceIndependent,
+        UnknownComputeUnitOf
+    }
+
+Get the computing device backing object `x`.
+
+Don't specialize `get_compute_unit`, specialize
+[`Adapt.get_compute_unit_impl`](@ref) instead.
+"""
+get_compute_unit(x) = get_compute_unit_impl(Union{}, x)
+export get_compute_unit
+
+
+"""
+    get_compute_unit_impl(::Type{TypeHistory}, x)::AbstractComputeUnit
+
+See [`get_compute_unit_impl`](@ref).
+
+Specializations that directly resolve the compute unit based on `x` can
+ignore `TypeHistory`:
+
+```julia
+Adapt.get_compute_unit_impl(@nospecialize(TypeHistory::Type), x::SomeType) = ...
+```
+"""
+function get_compute_unit_impl end
+
+
+@inline get_compute_unit_impl(@nospecialize(TypeHistory::Type), ::Array) = CPUDevice()
+
+# Guard against object reference loops:
+@inline get_compute_unit_impl(::Type{TypeHistory}, x::T) where {TypeHistory,T<:TypeHistory} = begin
+    UnknownComputeUnitOf(x) 
+end
+
+@generated function get_compute_unit_impl(::Type{TypeHistory}, x) where TypeHistory
+    if isbitstype(x)
+        :(ComputingDeviceIndependent())
+    else
+        NewTypeHistory = Union{TypeHistory, x}
+        impl = :(begin dev_0 = ComputingDeviceIndependent() end)
+        append!(impl.args, [:($(Symbol(:dev_, i)) = merge_compute_units(get_compute_unit_impl($NewTypeHistory, getfield(x, $i)), $(Symbol(:dev_, i-1)))) for i in 1:fieldcount(x)])
+        push!(impl.args, :(return $(Symbol(:dev_, fieldcount(x)))))
+        impl
+    end
+end


### PR DESCRIPTION
CUDA.jl, oneAPI.jl, etc. all provide a `...Device` type, but without a common supertype.

Likewise, our GPU packages all provide functionality to get the device that a given array lives on, but each defines it's own function for it. The latter was partially addressed in (JuliaGPU/KernelAbstractions.jl#269) but it's not an elegant solution (all Requires-based) and KernelAbstractions is a heavy dependency. This makes it tricky to address issues like JuliaArrays/ElasticArrays.jl#44. Some of the code mentioned in JuliaGPU/GPUArrays.jl#409 could also lighten it's dependencies with common "get-device" functionality (LinearSolve.jl, for example, seems to need GPUArray.jl only for a [`b isa GPUArrays.AbstractGPUArray`](https://github.com/SciML/LinearSolve.jl/blob/8e31fd75dd10f478fca74fd46477f7b342590ab9/src/default.jl#L12), similar for [DiffEqSensitivity.jl](https://github.com/SciML/DiffEqSensitivity.jl/blob/50fff85abca5452a90b155f8eb9833498d5b7aa4/src/concrete_solve.jl#L45)

This PR and supporting PRs for CUDA.jl, AMDGPU.jl, oneAPI.jl and KernelAbstractions.jl attempt to establish a common supertype for computing devices, and support for

* `get_computing_device(x)::AbstractComputingDevice`: Get the device `x` lives on, not limited to arrays (could e.g. be a whole ML model)

* `Adapt.adapt_storage(dev, x)`: Move `x` to device `dev`.

* `Sys.total_memory(dev)`: Get the total memory on `dev`

* `Sys.free_memory(dev)`: Get the free memory on `dev`

I think this will make it much easier to write generic device-independent code:

* Being able to query if data lives on a CPU or GPU without taking on heavy dependencies should comes in useful in many packages.

* Writing `adapt(CuDevice(n), x)` as an alternative to `adapt(CuArray, x)` seems very natural (esp. in multi-GPU scenarios): It corresponds to the user saying "let's run it on that GPU" instead of "with a different array type".

* Having the ability to query total and available memory can help with finding the right data chunk sizes before sending data to a device with `adapt(dev, data_partition)`.

This PR defines `AbstractComputingDevice`, `AbstractGPUDevice` and implements `GPUDevices`. It's very little code, there should be no load-time impact.


CC @vchuravy, @maleadt, @jpsamaroo, @ChrisRackauckas, @findmyway

Status:

* no tests yet while waiting for design comments from package maintainers

* CPU: functional

* CUDA: functional with with JuliaGPU/CUDA.jl#1520 (`CuDevice <: Adapt.AbstractGPUDevices`)

* AMDGPU: needs expert advice, draft is here: JuliaGPU/AMDGPU.jl#233

* oneAPI: functional (but not complete) with JuliaGPU/oneAPI.jl#185 (`ZeDevice <: Adapt.AbstractGPUDevice`)

* KernelAbstractions: funcional on CUDA with JuliaGPU/KernelAbstractions.jl#297 (replace `KernelAbstractions.Device` with `Adapt.AbstractComputingDevice`)
