### PR TITLE
Improve typestability.

### DIFF
--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -39,6 +39,21 @@ If we want this to work with custom structures, we need to extend `adapt_structu
 """
 adapt(to, x) = adapt_structure(to, x)
 
+"""
+    adapt(to)
+
+Create a function that adapts its argument according to `to`.
+If no specific adaptions have been registered for `to`, the returned function will be equivalent to `identity`.
+"""
+adapt(to) = Base.Fix1(adapt, to)
+if VERSION < v"1.9.0-DEV.857"
+    @eval function adapt(to::Type{T}) where {T}
+        (@isdefined T) || return Base.Fix1(adapt, to)
+        AT = Base.Fix1{typeof(adapt),Type{T}}
+        return $(Expr(:new, :AT, :adapt, :to))
+    end
+end
+
 adapt_structure(to, x) = adapt_storage(to, x)
 adapt_storage(to, x) = x
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,13 +1,6 @@
-# help struct to keep internal stability
-struct AdaptTo{T} <: Function
-  to::T
-  AdaptTo(to) = new{Core.Typeof(to)}(to)
-end
-(f::AdaptTo)(x) = adapt(f.to, x)
-
 # predefined adaptors for working with types from the Julia standard library
 
-adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(AdaptTo(to), xs)
+adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(adapt(to), xs)
 
 
 ## Closures

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,6 +1,13 @@
+# help struct to keep internal stability
+struct AdaptTo{T} <: Function
+  to::T
+  AdaptTo(to) = new{Core.Typeof(to)}(to)
+end
+(f::AdaptTo)(x) = adapt(f.to, x)
+
 # predefined adaptors for working with types from the Julia standard library
 
-adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(x->adapt(to,x), xs)
+adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(AdaptTo(to), xs)
 
 
 ## Closures
@@ -8,14 +15,14 @@ adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(x->adapt(to,x), xs)
 # two things can be captured: static parameters, and actual values (fields)
 
 @eval function adapt_structure(to, f::F) where {F<:Function}
-  isempty(F.parameters) && return f
-  nsparams = length(F.parameters) - nfields(f)
+  npar = length(F.parameters)
+  npar <= 0 && return f
+  nsparams = npar - nfields(f)
 
   # TODO: we should adapt the static parameters too
   #       (but adapt currently only works with values)
   sparams = ntuple(i->F.parameters[i], nsparams)
-  fields = ntuple(i->adapt(to, getfield(f, i)), nfields(f))
-
+  fields = adapt(to, ntuple(i->getfield(f, i), nfields(f)))
   # TODO: this assumes the typevars of the closure matches the sparams + fields.
   #       that may not always be true, and definitely isn't for arbitrary callable objects.
   ftyp = F.name.wrapper{sparams..., map(Core.Typeof, fields)...}
@@ -28,7 +35,7 @@ end
 import Base.Broadcast: Broadcasted, Extruded
 
 adapt_structure(to, bc::Broadcasted{Style}) where Style =
-  Broadcasted{Style}(adapt(to, bc.f), map(arg->adapt(to, arg), bc.args), bc.axes)
+  Broadcasted{Style}(adapt(to, bc.f), adapt(to, bc.args), bc.axes)
 
 adapt_structure(to, ex::Extruded) =
     Extruded(adapt(to, ex.x), ex.keeps, ex.defaults)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -9,8 +9,12 @@ export WrappedArray
 
 adapt_structure(to, A::SubArray) =
       SubArray(adapt(to, Base.parent(A)), adapt(to, parentindices(A)))
-adapt_structure(to, A::PermutedDimsArray) =
-      PermutedDimsArray(adapt(to, Base.parent(A)), permutation(A))
+function adapt_structure(to, A::PermutedDimsArray)
+      perm = permutation(A)
+      iperm = invperm(perm)
+      A′ = adapt(to, Base.parent(A))
+      PermutedDimsArray{Base.eltype(A′),Base.ndims(A′),perm,iperm,typeof(A′)}(A′)
+end
 adapt_structure(to, A::Base.ReshapedArray) =
       Base.reshape(adapt(to, Base.parent(A)), size(A))
 @static if isdefined(Base, :NonReshapedReinterpretArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Test
 # custom array type
 
 struct CustomArray{T,N} <: AbstractArray{T,N}
-    arr::Array
+    arr::Array{T,N}
 end
 
 CustomArray(x::Array{T,N}) where {T,N} = CustomArray{T,N}(x)
@@ -31,7 +31,7 @@ macro test_adapt(to, src_expr, dst_expr, typ=nothing)
         src = $(esc(src_expr))
         dst = $(esc(dst_expr))
 
-        res = adapt($(esc(to)), src)
+        res = @inferred(adapt($(esc(to)), src))
         @test res == dst
         @test typeof(res) == typeof(dst)
 


### PR DESCRIPTION
1. replace `x->adapt(to,x)` with `AdaptTo(to)` to avoid https://github.com/JuliaLang/julia/issues/23618. (We have adaptor <: Type, e.g. `Array`)
2. use `PermutedDimsArray`'s inner constructor to avoid https://github.com/JuliaLang/julia/issues/46008