### PR TITLE
Adapt to static arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,21 @@ version = "3.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
+Requires = "1"
 julia = "1.6"
+
+[extensions]
+AdaptStaticArraysExt = "StaticArrays"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [targets]
-test = ["Test"]
+test = ["StaticArrays", "Test"]
+
+[weakdeps]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/ext/AdaptStaticArraysExt.jl
+++ b/ext/AdaptStaticArraysExt.jl
@@ -1,0 +1,8 @@
+module AdaptStaticArraysCoreExt
+
+using Adapt
+isdefined(Base, :get_extension) ? (using StaticArrays) : (using ..StaticArrays)
+
+Adapt.adapt_storage(::Type{<:SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
+
+end

--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -67,4 +67,11 @@ include("arrays.jl")
 # helpers
 include("macro.jl")
 
+import Requires
+@static if !isdefined(Base, :get_extension)
+    function __init__()
+        Requires.@require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin include("../ext/AdaptStaticArraysExt.jl") end
+    end
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,3 +223,8 @@ end
     bc = Base.broadcasted(f(mat.arr), (mat.arr,))
     @test typeof(copy(adapt(CustomArray, bc))) == typeof(broadcast(f(mat), (mat,)))
 end
+
+@testset "StaticArrays" begin
+    using StaticArrays
+    adapt(SArray, [1,2,3]) isa SArray
+end


### PR DESCRIPTION
Uses package extensions so that it does not add the dependency. Is setup for backwards compatibility to pre-1.9 versions.

Should follow up with https://github.com/JuliaArrays/ArrayInterface.jl/pull/380