### PR TITLE
Fix StaticArrays extension.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,21 @@
 name = "Adapt"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.6.0"
+version = "3.6.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
-[compat]
-Requires = "1"
-julia = "1.6"
+[weakdeps]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 AdaptStaticArraysExt = "StaticArrays"
+
+[compat]
+Requires = "1"
+StaticArrays = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -19,6 +23,3 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [targets]
 test = ["StaticArrays", "Test"]
-
-[weakdeps]
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/ext/AdaptStaticArraysExt.jl
+++ b/ext/AdaptStaticArraysExt.jl
@@ -1,8 +1,9 @@
-module AdaptStaticArraysCoreExt
+module AdaptStaticArraysExt
 
 using Adapt
 isdefined(Base, :get_extension) ? (using StaticArrays) : (using ..StaticArrays)
 
 Adapt.adapt_storage(::Type{<:SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
+Adapt.adapt_storage(::Type{SArray}, xs::Array) = SArray{Tuple{size(xs)...}}(xs)
 
 end

--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -67,11 +67,14 @@ include("arrays.jl")
 # helpers
 include("macro.jl")
 
-import Requires
+if !isdefined(Base, :get_extension)
+using Requires
+end
+
 @static if !isdefined(Base, :get_extension)
-    function __init__()
-        Requires.@require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin include("../ext/AdaptStaticArraysExt.jl") end
-    end
+function __init__()
+    @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin include("../ext/AdaptStaticArraysExt.jl") end
+end
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,5 +226,9 @@ end
 
 @testset "StaticArrays" begin
     using StaticArrays
-    adapt(SArray, [1,2,3]) isa SArray
+    @test_adapt SArray{Tuple{3}} [1,2,3] SArray{Tuple{3}}([1,2,3])
+
+    # can't possibly infer this one, so not using @test_adapt
+    #@test_adapt SArray           [1,2,3] SArray{Tuple{3}}([1,2,3])
+    @test adapt(SArray, [1,2,3]) === SArray{Tuple{3}}([1,2,3])
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/Adapt.jl/pull/59, which introduced a broken extension package (didn't load, didn't actually adapt) with nonfunctional tests.

Closes https://github.com/JuliaGPU/Adapt.jl/issues/61

cc @ChrisRackauckas