### PR TITLE
Remove ndims/eltype, and simplify parent type queries.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Adapt"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.7.2"
+version = "4.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,6 @@ struct CustomArray{T,N} <: AbstractArray{T,N}
     arr::Array{T,N}
 end
 
-CustomArray(x::Array{T,N}) where {T,N} = CustomArray{T,N}(x)
 Adapt.adapt_storage(::Type{<:CustomArray}, xs::Array) = CustomArray(xs)
 
 Base.size(x::CustomArray, y...) = size(x.arr, y...)
@@ -58,7 +57,6 @@ AnyCustomArray{T,N} = Union{CustomArray,WrappedArray{T,N,CustomArray,CustomArray
 struct Wrapper{T}
     arr::T
 end
-Wrapper(x::T) where T = Wrapper{T}(x)
 Adapt.adapt_structure(to, xs::Wrapper) = Wrapper(adapt(to, xs.arr))
 @test_adapt CustomArray Wrapper(mat.arr) Wrapper(mat)
 
@@ -192,12 +190,13 @@ end
 
 
 @testset "type information" begin
-    @test Adapt.ndims(LinearAlgebra.Transpose{Float64,Array{Float64,1}}) == 2
-    @test Adapt.ndims(LinearAlgebra.Symmetric{Float64,Matrix{Float64}}) == 2
-    @test Adapt.ndims(Adapt.WrappedSubArray{Float64,3,Array{Float64,3}}) == 3
+    # single wrapping
+    @test parent_type(Transpose{Int,Array{Int,1}}) == Array{Int,1}
+    @test parent_type(Transpose{Int,Transpose{Int,Array{Int,1}}}) == Transpose{Int,Array{Int,1}}
 
-    @test Adapt.parent(LinearAlgebra.Transpose{Float64,Array{Float64,1}}) == Array
-    @test Adapt.parent(Adapt.WrappedSubArray{Float64,3,Array{Float64,3}}) == Array
+    # double wrapping
+    @test unwrap_type(Transpose{Int,Array{Int,1}}) == Array{Int,1}
+    @test unwrap_type(Transpose{Int,Transpose{Int,Array{Int,1}}}) == Array{Int,1}
 end
 
 


### PR DESCRIPTION
Instead of returning the raw typename, provide the full type so that callers can use type variables, if required.
Also provide a version that fully unpeels the array wrapper.
And remove `ndims`/`eltype`, which are queries that Base supports already.

These are breaking changes, but needed for https://github.com/JuliaGPU/CUDA.jl/issues/2191 in order to provide the full parent array's typevars (i.e., the buffer type) to the broadcast implementation.

Also fixes https://github.com/JuliaGPU/Adapt.jl/issues/72