### PR TITLE
Use recursion to fix inference failure

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1,8 +1,10 @@
 # predefined adaptors for working with types from the Julia standard library
 
-# Use recursion on tuples to avoid inference bail-out in `map`
+# Use recursion to avoid inference bail-out in `map`
 #adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(adapt(to), xs)
-adapt_structure(to, xs::NamedTuple) = map(x->adapt(to,x), xs)
+adapt_structure(to, xs::NamedTuple{names}) where {names} =
+    NamedTuple{names}(adapt_structure(to, Tuple(xs)))
+
 adapt_structure(to, xs::Tuple) = _adapt_tuple_structure(to, xs)
 _adapt_tuple_structure(to, xs::Tuple) =
   (adapt(to, first(xs)), _adapt_tuple_structure(to, Base.tail(xs))...)

--- a/src/base.jl
+++ b/src/base.jl
@@ -2,9 +2,7 @@
 
 # Use recursion to avoid inference bail-out in `map`
 #adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(adapt(to), xs)
-adapt_structure(to, xs::NamedTuple{names}) where {names} =
-    NamedTuple{names}(adapt_structure(to, Tuple(xs)))
-
+adapt_structure(to, xs::NamedTuple) = map(adapt(to), xs)
 adapt_structure(to, xs::Tuple) = _adapt_tuple_structure(to, xs)
 _adapt_tuple_structure(to, xs::Tuple) =
   (adapt(to, first(xs)), _adapt_tuple_structure(to, Base.tail(xs))...)

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,13 +1,13 @@
 # predefined adaptors for working with types from the Julia standard library
 
-_radapt_structure(to, xs::Tuple) =
-  (adapt(to, first(xs)), _radapt_structure(to, Base.tail(xs))...)
-_radapt_structure(to, xs::Tuple{}) = ()
-_radapt_structure(to, xs::Tuple{<:Any}) =
-  (adapt(to, first(xs)), )
 # Use recursion on tuples to avoid inference bail-out in `map`
-adapt_structure(to, xs::Tuple) = _radapt_structure(to, xs)
+#adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(adapt(to), xs)
 adapt_structure(to, xs::NamedTuple) = map(x->adapt(to,x), xs)
+adapt_structure(to, xs::Tuple) = _adapt_tuple_structure(to, xs)
+_adapt_tuple_structure(to, xs::Tuple) =
+  (adapt(to, first(xs)), _adapt_tuple_structure(to, Base.tail(xs))...)
+_adapt_tuple_structure(to, xs::Tuple{}) = ()
+_adapt_tuple_structure(to, xs::Tuple{<:Any}) = (adapt(to, first(xs)), )
 
 
 ## Closures

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,6 +1,13 @@
 # predefined adaptors for working with types from the Julia standard library
 
-adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(adapt(to), xs)
+_radapt_structure(to, xs::Tuple) =
+  (adapt(to, first(xs)), _radapt_structure(to, Base.tail(xs))...)
+_radapt_structure(to, xs::Tuple{}) = ()
+_radapt_structure(to, xs::Tuple{<:Any}) =
+  (adapt(to, first(xs)), )
+# Use recursion on tuples to avoid inference bail-out in `map`
+adapt_structure(to, xs::Tuple) = _radapt_structure(to, xs)
+adapt_structure(to, xs::NamedTuple) = map(x->adapt(to,x), xs)
 
 
 ## Closures


### PR DESCRIPTION
This PR inlines, and uses recursion to fix cases where `Adapt.adapt` performs runtime dispatch due to either recursion limits, or inability to unroll `map` on `Tuple`s. I have and will post a reproducer shortly.

Closes #79.