### PR TITLE
Revert "Use recursion to fix inference failure"

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1,13 +1,6 @@
 # predefined adaptors for working with types from the Julia standard library
 
-# Use recursion to avoid inference bail-out in `map`
-#adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(adapt(to), xs)
-adapt_structure(to, xs::NamedTuple) = map(adapt(to), xs)
-adapt_structure(to, xs::Tuple) = _adapt_tuple_structure(to, xs)
-_adapt_tuple_structure(to, xs::Tuple) =
-  (adapt(to, first(xs)), _adapt_tuple_structure(to, Base.tail(xs))...)
-_adapt_tuple_structure(to, xs::Tuple{}) = ()
-_adapt_tuple_structure(to, xs::Tuple{<:Any}) = (adapt(to, first(xs)), )
+adapt_structure(to, xs::Union{Tuple,NamedTuple}) = map(adapt(to), xs)
 
 
 ## Closures


### PR DESCRIPTION
Reverts JuliaGPU/Adapt.jl#78

Looks like this introduces inference crashes during CUDA.jl CI: from https://buildkite.com/julialang/gpuarrays-dot-jl/builds/814#018e13b6-4936-4fb9-8d88-4402694019e6

```
      From worker 4:	Internal error: stack overflow in type inference of _adapt_tuple_structure(CUDA.KernelAdaptor, NTuple{6373, UInt64}).
      From worker 4:	This might be caused by recursion over very long tuples or argument lists.
```

cc @charleskawczynski 