### PR TITLE
Preserve eltype of StepRangeLen

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -76,8 +76,8 @@ adapt_structure(to, r::Base.OneTo) = Base.OneTo(adapt(to, r.stop))
 adapt_structure(to, r::StepRange) =
   StepRange(adapt(to, r.start), adapt(to, r.step), adapt(to, r.stop))
 
-adapt_structure(to, r::StepRangeLen) =
-  StepRangeLen(adapt(to, r.ref), adapt(to, r.step), r.len, r.offset)
+adapt_structure(to, r::StepRangeLen{T}) where T =
+  StepRangeLen{T}(adapt(to, r.ref), adapt(to, r.step), r.len, r.offset)
 
 adapt_structure(to, r::Base.Slice) = Base.Slice(adapt(to, r.indices))
 


### PR DESCRIPTION
This PR changes `adapt_structure(to, ::StepRangeLen{T})` to (I hope) preserve the eltype `T` of the range. This prevents `Float32` ranges from being spuriously promoted to `Float64` on the GPU.

Closes #87 