### PR TITLE
Define `adapt_structure` for CartesianIndices

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -83,3 +83,7 @@ adapt_structure(to, r::Base.Slice) = Base.Slice(adapt(to, r.indices))
 
 adapt_structure(to, r::LinRange) =
   LinRange(adapt(to, r.start), adapt(to, r.stop), r.len)
+
+## CartesianIndices
+
+adapt_structure(to, ci::CartesianIndices) = ci

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,3 +255,7 @@ end
     @test adapt(Array, Base.Slice(1:10)) === Base.Slice(1:10)
     @test adapt(Array, LinRange(1,2,10)) === LinRange(1,2,10)
 end
+
+@testset "CartesianIndices" begin
+    @test adapt(Array, CartesianIndices((1,2,3))) === CartesianIndices((1,2,3))
+end


### PR DESCRIPTION
This PR defines `adapt_structure` for `CartesianIndices` to be a no-op, as this is already a subtype of `AbstractArray`. Handling this lazily allows users to adapt between cpu and gpu without materializing `CartesianIndices`.

For #92