### PR TITLE
Drop Requires.jl dependency and use native Julia v1.10 extensions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.7'
-          - '1.8'
-          - '1.9'
           - '1.10'
           - '1.11'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "4.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [weakdeps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -15,9 +14,8 @@ AdaptSparseArraysExt = "SparseArrays"
 AdaptStaticArraysExt = "StaticArrays"
 
 [compat]
-Requires = "1"
 StaticArrays = "1"
-julia = "1.6"
+julia = "1.10"
 LinearAlgebra = "1"
 SparseArrays = "1"
 

--- a/ext/AdaptSparseArraysExt.jl
+++ b/ext/AdaptSparseArraysExt.jl
@@ -1,7 +1,7 @@
 module AdaptSparseArraysExt
 
 using Adapt
-isdefined(Base, :get_extension) ? (using SparseArrays) : (using ..SparseArrays)
+using SparseArrays
 
 Adapt.adapt_storage(::Type{Array}, xs::SparseVector) = xs
 Adapt.adapt_storage(::Type{Array}, xs::SparseMatrixCSC) = xs

--- a/ext/AdaptStaticArraysExt.jl
+++ b/ext/AdaptStaticArraysExt.jl
@@ -1,7 +1,7 @@
 module AdaptStaticArraysExt
 
 using Adapt
-isdefined(Base, :get_extension) ? (using StaticArrays) : (using ..StaticArrays)
+using StaticArrays
 
 Adapt.adapt_storage(::Type{<:SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
 Adapt.adapt_storage(::Type{SArray}, xs::Array) = SArray{Tuple{size(xs)...}}(xs)

--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -67,19 +67,5 @@ include("arrays.jl")
 # helpers
 include("macro.jl")
 
-if !isdefined(Base, :get_extension)
-using Requires
-end
-
-@static if !isdefined(Base, :get_extension)
-function __init__()
-    @require SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf" begin
-        include("../ext/AdaptSparseArraysExt.jl")
-    end
-    @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin
-        include("../ext/AdaptStaticArraysExt.jl")
-    end
-end
-end
 
 end # module


### PR DESCRIPTION
## Summary
- Remove Requires.jl dependency and switch to native Julia v1.10 package extensions
- Update minimum Julia version to v1.10 (the new LTS)
- Simplify extension loading code

## Changes
- **Project.toml**: Remove Requires.jl from dependencies, update Julia compat to v1.10
- **src/Adapt.jl**: Remove conditional extension loading code that used Requires.jl
- **ext/*.jl**: Simplify extension modules to use standard imports instead of conditional logic
- **.github/workflows/Test.yml**: Update CI to test only Julia v1.10 and newer

## Motivation
Julia v1.10 is now the LTS release, so we can drop support for older versions and remove the Requires.jl compatibility layer. This simplifies the codebase and removes an unnecessary dependency.

## Test plan
✅ Tests pass locally on Julia v1.10
✅ Package extensions load correctly
✅ CI updated to test on v1.10, v1.11, and nightly

🤖 Generated with [Claude Code](https://claude.ai/code)