### PR TITLE
Add some missed types to WrappedArray

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -48,8 +48,12 @@ adapt_structure(to, A::LinearAlgebra.Diagonal) =
       LinearAlgebra.Diagonal(adapt(to, parent(A)))
 adapt_structure(to, A::LinearAlgebra.Tridiagonal) =
       LinearAlgebra.Tridiagonal(adapt(to, A.dl), adapt(to, A.d), adapt(to, A.du))
+adapt_structure(to, A::LinearAlgebra.Bidiagonal) =
+      LinearAlgebra.Bidiagonal(adapt(to, A.dv), adapt(to, A.ev), A.uplo)
 adapt_structure(to, A::LinearAlgebra.Symmetric) =
       LinearAlgebra.Symmetric(adapt(to, parent(A)))
+adapt_structure(to, A::LinearAlgebra.Hermitian) =
+      LinearAlgebra.Hermitian(adapt(to, parent(A)))
 
 
 # we generally don't support multiple layers of wrappers, but some occur often

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,7 +186,7 @@ dl = CustomArray{Float64,1}(rand(2))
 du = CustomArray{Float64,1}(rand(2))
 d = CustomArray{Float64,1}(rand(3))
 @test_adapt CustomArray Tridiagonal(dl.arr, d.arr, du.arr) Tridiagonal(dl, d, du) AnyCustomArray
-@test_adapt CustomArray Bidiagonal(d.arr, du.arr) Bidiagonal(d, du) AnyCustomArray
+@test_adapt CustomArray Bidiagonal(d.arr, du.arr, 'U') Bidiagonal(d, du, 'U') AnyCustomArray
 end
 
 


### PR DESCRIPTION
Hermitian and Bidiagonal aren't included although they probably should be.

This should fix the following behaviour on 1.12:

```julia
julia> using CUDA, LinearAlgebra

julia> A = CUDA.rand(8,8);

julia> A = A + A';

julia> Ah = Hermitian(A);

julia> @which collect(Ah)
collect(A::AbstractArray)
     @ Base array.jl:730

julia> As = Symmetric(A);

julia> @which collect(As)
collect(X::GPUArraysCore.AnyGPUArray)
     @ GPUArrays ~/.julia/packages/GPUArrays/ZRk7Q/src/host/abstractarray.jl:154
```