### PR TITLE
Test downstream packages

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,142 @@
+steps:
+  - group: "CUDA"
+    key: "cuda"
+    steps:
+      - label: "Julia {{matrix.julia}}"
+        plugins:
+          - JuliaCI/julia#v1:
+              version: "{{matrix.julia}}"
+          - JuliaCI/julia-test#v1:
+              test_args: "--quickfail"
+              allow_reresolve: false
+          - JuliaCI/julia-coverage#v1:
+              dirs:
+                - src
+                - ext
+        agents:
+          queue: "juliagpu"
+          cuda: "*"
+        commands: |
+          julia --project -e '
+            using Pkg
+      
+            adapt  = pwd()
+            devdir = mktempdir()
+            cuda   = joinpath(devdir, "CUDA")
+            println("--- :julia: Installing TestEnv")
+            Pkg.activate(; temp=true)
+            Pkg.add("TestEnv")
+            using TestEnv
+
+            println("--- :julia: Installing CUDA")
+            withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
+                    "JULIA_PKG_DEVDIR" => devdir) do
+              Pkg.develop("CUDA")
+              Pkg.activate(cuda)
+
+              try
+                Pkg.develop([PackageSpec(path=adapt), PackageSpec(path=cuda)])
+                TestEnv.activate()
+              catch err
+                @error "Could not install CUDA" exception=(err,catch_backtrace())
+                exit(3)
+              finally
+                Pkg.activate(cuda)
+              end
+            end
+      
+            println("+++ :julia: Running tests")
+            Pkg.test(; coverage=true)'
+        if: |
+          build.message =~ /\[only tests\]/ ||
+          build.message =~ /\[only cuda\]/ ||
+          build.message !~ /\[only/ &&
+            build.message !~ /\[skip tests\]/ &&
+            build.message !~ /\[skip cuda\]/
+        timeout_in_minutes: 60
+        matrix:
+          setup:
+            julia:
+              - "1.10"
+              - "1.11"
+              - "1.12-nightly"
+              - "nightly"
+          adjustments:
+            - with:
+                julia: "1.12-nightly"
+              soft_fail: true
+            - with:
+                julia: "nightly"
+              soft_fail: true
+
+  - group: "AMDGPU"
+    key: "amdgpu"
+    steps:
+      - label: "Julia {{matrix.julia}}"
+        plugins:
+          - JuliaCI/julia#v1:
+              version: "{{matrix.julia}}"
+          - JuliaCI/julia-test#v1:
+              test_args: "--quickfail"
+              allow_reresolve: false
+          - JuliaCI/julia-coverage#v1:
+              dirs:
+                - src
+                - ext
+        agents:
+          queue: "juliagpu"
+          rocm: "*"
+          rocmgpu: "*"
+        commands: |
+          julia --project -e '
+            using Pkg
+      
+            adapt  = pwd()
+            devdir = mktempdir()
+            amdgpu = joinpath(devdir, "AMDGPU")
+            println("--- :julia: Installing TestEnv")
+            Pkg.activate(; temp=true)
+            Pkg.add("TestEnv")
+            using TestEnv
+
+            println("--- :julia: Installing AMDGPU")
+            withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
+                    "JULIA_PKG_DEVDIR" => devdir) do
+              Pkg.develop("AMDGPU")
+              Pkg.activate(amdgpu)
+
+              try
+                Pkg.develop([PackageSpec(path=adapt), PackageSpec(path=amdgpu)])
+                TestEnv.activate()
+              catch err
+                @error "Could not install AMDGPU" exception=(err,catch_backtrace())
+                exit(3)
+              finally
+                Pkg.activate(amdgpu)
+              end
+            end
+      
+            println("+++ :julia: Running tests")
+            Pkg.test(; coverage=true)'
+        if: |
+          build.message =~ /\[only tests\]/ ||
+          build.message =~ /\[only amdgpu\]/ ||
+          build.message !~ /\[only/ &&
+            build.message !~ /\[skip tests\]/ &&
+            build.message !~ /\[skip amdgpu\]/
+        timeout_in_minutes: 60
+        matrix:
+          setup:
+            julia:
+              - "1.10"
+              - "1.11"
+              - "1.12-nightly"
+              - "nightly"
+          adjustments:
+            - with:
+                julia: "1.12-nightly"
+              soft_fail: true
+            - with:
+                julia: "nightly"
+              soft_fail: true
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
                     "JULIA_PKG_DEVDIR" => devdir) do
               try
                 Pkg.develop("CUDA")
-                TestEnv.activate()
+                TestEnv.activate("CUDA")
               catch err
                 @error "Could not install CUDA" exception=(err,catch_backtrace())
                 exit(3)
@@ -101,7 +101,7 @@ steps:
                     "JULIA_PKG_DEVDIR" => devdir) do
               try
                 Pkg.develop("AMDGPU")
-                TestEnv.activate()
+                TestEnv.activate("AMDGPU")
               catch err
                 @error "Could not install AMDGPU" exception=(err,catch_backtrace())
                 exit(3)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,11 +31,8 @@ steps:
             println("--- :julia: Installing CUDA")
             withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
                     "JULIA_PKG_DEVDIR" => devdir) do
-              Pkg.develop("CUDA")
-              Pkg.activate(cuda)
-
               try
-                Pkg.develop([PackageSpec(path=adapt), PackageSpec(path=cuda)])
+                Pkg.develop("CUDA")
                 TestEnv.activate()
               catch err
                 @error "Could not install CUDA" exception=(err,catch_backtrace())
@@ -102,11 +99,8 @@ steps:
             println("--- :julia: Installing AMDGPU")
             withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
                     "JULIA_PKG_DEVDIR" => devdir) do
-              Pkg.develop("AMDGPU")
-              Pkg.activate(amdgpu)
-
               try
-                Pkg.develop([PackageSpec(path=adapt), PackageSpec(path=amdgpu)])
+                Pkg.develop("AMDGPU")
                 TestEnv.activate()
               catch err
                 @error "Could not install AMDGPU" exception=(err,catch_backtrace())


### PR DESCRIPTION
Should hopefully catch things like https://github.com/JuliaGPU/Adapt.jl/pull/95 breaking CUDA earlier. This is a lot of builds but PRs to this repo are infrequent and behaviour can vary between Base versions so I thought it made sense to test RCs as well.