### PR TITLE
Defer field lookup in @adapt_structure to fix nested-macro use.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Adapt"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "4.5.0"
+version = "4.5.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -5,10 +5,10 @@ Define a method `adapt_structure(to, obj::T)` which calls `adapt_structure` on e
 of `obj` and constructs a new instance of `T` using the default constuctor `T(...)`.
 """
 macro adapt_structure(T)
-    names = fieldnames(Core.eval(__module__, T))
-    quote
-        function Adapt.adapt_structure(to, obj::$(esc(T)))
-            $(esc(T))($([:(Adapt.adapt_structure(to, obj.$name)) for name in names]...))
+    esc(quote
+        @generated function Adapt.adapt_structure(to, obj::$T)
+            assignments = Any[:(Adapt.adapt_structure(to, obj.$name)) for name in fieldnames(obj)]
+            return Expr(:call, $T, assignments...)
         end
-    end    
+    end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,6 +214,13 @@ end
 
     @test_adapt CustomArray MyStruct(u,v) MyStruct(CustomArray(u), CustomArray(v))
     @test_adapt CustomArray MyStruct(u,1.0) MyStruct(CustomArray(u), 1.0)
+
+    # Bug 102; type defined in the same block as @adapt_structure
+    struct LocalStruct
+        x::Int
+    end
+    Adapt.@adapt_structure LocalStruct
+    @test adapt(CustomArray, LocalStruct(1)) === LocalStruct(1)
 end
 
 


### PR DESCRIPTION
The macro previously called `Core.eval(__module__, T)` at expansion time, which fails when @adapt_structure is invoked inside another macro that wraps its body in a function (e.g. @testset), because the struct definition has not run yet at macroexpand time. Switch to a @generated function so field names are queried at codegen time, when the type is guaranteed to exist. The emitted IR is identical to the original (direct getfield + %new), so there is no performance regression.

Fixes https://github.com/JuliaGPU/Adapt.jl/issues/102