### PR TITLE
Fix @adapt_structure for modules that only import the macro.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Adapt"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "4.5.1"
+version = "4.5.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -5,10 +5,10 @@ Define a method `adapt_structure(to, obj::T)` which calls `adapt_structure` on e
 of `obj` and constructs a new instance of `T` using the default constuctor `T(...)`.
 """
 macro adapt_structure(T)
-    esc(quote
-        @generated function Adapt.adapt_structure(to, obj::$T)
-            assignments = Any[:(Adapt.adapt_structure(to, obj.$name)) for name in fieldnames(obj)]
-            return Expr(:call, $T, assignments...)
+    quote
+        @generated function $Adapt.adapt_structure($(esc(:to)), $(esc(:obj))::$(esc(T)))
+            assignments = Any[:($$Adapt.adapt_structure(to, obj.$name)) for name in fieldnames($(esc(:obj)))]
+            return Expr(:call, $(esc(T)), assignments...)
         end
-    end)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -221,6 +221,17 @@ end
     end
     Adapt.@adapt_structure LocalStruct
     @test adapt(CustomArray, LocalStruct(1)) === LocalStruct(1)
+
+    # The macro must work in modules that only import @adapt_structure,
+    # not the Adapt module itself (e.g. `using Adapt: @adapt_structure`).
+    @eval module ModuleOnlyImportingMacro
+        using Adapt: @adapt_structure
+        struct S
+            x::Int
+        end
+        @adapt_structure S
+    end
+    @test adapt(CustomArray, ModuleOnlyImportingMacro.S(1)) === ModuleOnlyImportingMacro.S(1)
 end
 
 


### PR DESCRIPTION
The previous fix used `esc(quote ... end)`, which made the generated code resolve `Adapt.adapt_structure` in the caller's module. This broke modules that do `using Adapt: @adapt_structure` (e.g. DataInterpolationsND) because `Adapt` itself is not bound there.

Switch to value-interpolating the Adapt module directly via `$Adapt` (and `$$Adapt` to reach into the inner quote that runs at codegen time). The function-argument names `to` and `obj` are escaped explicitly so hygiene does not gensym them — that keeps them matching the literal `:to`/`:obj` symbols inside the inner quote. The resulting IR is unchanged (direct getfield + %new).

Fixes https://github.com/JuliaGPU/Adapt.jl/issues/108