### PR TITLE
Preserve uplo when adapting Symmetric/Hermitian wrappers.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Adapt"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "4.6.0"
+version = "4.6.1"
 
 [workspace]
 projects = ["test"]

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -46,9 +46,9 @@ adapt_structure(to, A::LinearAlgebra.Tridiagonal) =
 adapt_structure(to, A::LinearAlgebra.Bidiagonal) =
       LinearAlgebra.Bidiagonal(adapt(to, A.dv), adapt(to, A.ev), A.uplo)
 adapt_structure(to, A::LinearAlgebra.Symmetric) =
-      LinearAlgebra.Symmetric(adapt(to, parent(A)))
+      LinearAlgebra.Symmetric(adapt(to, parent(A)), A.uplo == 'U' ? :U : :L)
 adapt_structure(to, A::LinearAlgebra.Hermitian) =
-      LinearAlgebra.Hermitian(adapt(to, parent(A)))
+      LinearAlgebra.Hermitian(adapt(to, parent(A)), A.uplo == 'U' ? :U : :L)
 
 
 # we generally don't support multiple layers of wrappers, but some occur often

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,6 +175,8 @@ using LinearAlgebra
 @test_adapt CustomArray UnitUpperTriangular(mat.arr) UnitUpperTriangular(mat) AnyCustomArray
 @test_adapt CustomArray Symmetric(mat.arr) Symmetric(mat) AnyCustomArray
 @test_adapt CustomArray Hermitian(mat.arr) Hermitian(mat) AnyCustomArray
+@test_adapt CustomArray Symmetric(mat.arr, :L) Symmetric(mat, :L) AnyCustomArray
+@test_adapt CustomArray Hermitian(mat.arr, :L) Hermitian(mat, :L) AnyCustomArray
     
 @test_adapt CustomArray Diagonal(vec.arr) Diagonal(vec) AnyCustomArray
 


### PR DESCRIPTION
`adapt_structure` reconstructed these wrappers without passing the `uplo` field, silently turning lower-triangle views into upper ones whenever kernel arguments were adapted.