### PR TITLE
Mark adapt_structure and adapt_storage public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Adapt"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "4.6.1"
+version = "4.7.0"
 
 [workspace]
 projects = ["test"]

--- a/src/Adapt.jl
+++ b/src/Adapt.jl
@@ -50,6 +50,14 @@ adapt(to) = Base.Fix1(adapt, to)
 adapt_structure(to, x) = adapt_storage(to, x)
 adapt_storage(to, x) = x
 
+# `adapt_structure` and `adapt_storage` are the documented extension points that
+# downstream packages overload (see the `adapt` docstring above and the README),
+# so mark them public. `eval(Expr(:public, ...))` keeps this file parsing on the
+# Julia 1.10 floor, where the `public` keyword does not yet exist.
+@static if VERSION >= v"1.11.0-DEV.469"
+    eval(Expr(:public, :adapt_structure, :adapt_storage))
+end
+
 # structure rules
 include("base.jl")
 include("wrappers.jl")


### PR DESCRIPTION
`adapt_structure` and `adapt_storage` are the documented extension points downstream packages overload (the `adapt` docstring and the README both say to "implement methods of `adapt_structure` and `adapt_storage`"), but they're neither exported nor marked `public`. Tooling that checks public-API usage (e.g. ExplicitImports.jl, increasingly run in SciML/JuliaGPU test suites) therefore flags every `Adapt.adapt_structure` override as a non-public access, forcing per-repo ignore-lists across the ecosystem.

This marks both names `public` via `eval(Expr(:public, ...))` guarded on `VERSION >= v"1.11"` so the file still parses on Adapt's Julia 1.10 floor. **No new dependency** and no behavior change.

Verified: `Base.ispublic(Adapt, :adapt_structure) == true` (and `adapt_storage`) on 1.12; loads cleanly on the 1.10 LTS; full test suite passes; Runic-clean. version 4.6.1 → 4.7.0.